### PR TITLE
Fix bug with parsing prefixed opcodes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,18 +1,14 @@
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    b.addModule(.{
+        .name = "wasmparser",
+        .source_file = .{ .path = "src/lib.zig" },
+    });
 
-    const lib = b.addStaticLibrary("wasmparser", "src/lib.zig");
-    lib.setBuildMode(mode);
-    lib.install();
-
-    var main_tests = b.addTest("tests/test.zig");
-    main_tests.addPackagePath("wasmparser", "src/lib.zig");
-    main_tests.setBuildMode(mode);
-
-    const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    var tests = b.addTest(.{
+        .root_source_file = .{ .path = "tests/test.zig" },
+    });
+    tests.addModule("wasmparser", b.modules.get("wasmparser").?);
+    b.step("test", "Run library tests").dependOn(&tests.step);
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -271,7 +271,7 @@ fn Parser(comptime ReaderType: type) type {
                                     else => |e| return e,
                                 }
 
-                                code.body = instructions.toOwnedSlice();
+                                code.body = try instructions.toOwnedSlice();
                             }
                             try assertEnd(code_reader);
                         }
@@ -302,7 +302,7 @@ fn Parser(comptime ReaderType: type) type {
                 error.EndOfStream => {},
                 else => |e| return e,
             }
-            module.custom = custom_sections.toOwnedSlice();
+            module.custom = try custom_sections.toOwnedSlice();
             return module;
         }
     };

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -56,7 +56,6 @@ fn MergedEnum(comptime T: type, comptime fields: []const TypeInfo.EnumField) typ
     std.mem.copy(TypeInfo.EnumField, new_fields[old_fields.len..], fields);
 
     return @Type(.{ .Enum = .{
-        .layout = .Auto,
         .tag_type = u8,
         .fields = &new_fields,
         .decls = &.{},

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -300,6 +300,5 @@ pub const SecondaryOpcode = enum(u8) {
     _,
 };
 
-pub const need_secondary = @intToEnum(wasm.Opcode, 0xFC);
 pub const table_get = @intToEnum(wasm.Opcode, 0x25);
 pub const table_set = @intToEnum(wasm.Opcode, 0x26);

--- a/tests/test.zig
+++ b/tests/test.zig
@@ -67,18 +67,7 @@ test "tests/call_indirect.wasm" {
     });
 }
 
-test "tests/wasi_hello_world.wasm except code" {
-    const file = @embedFile("wasi_hello_world.wasm");
-    var stream = std.io.fixedBufferStream(file);
-    var options: wasmparser.parser.Options = .{};
-    // skip code section
-    options.skip_section[@enumToInt(std.wasm.Section.code)] = true;
-    var result = try wasmparser.parser.parseWithOptions(ally, stream.reader(), options);
-    defer result.deinit(ally);
-}
-
 test "tests/wasi_hello_world.wasm" {
-    // This is not working, seems something not supported by parser in code section
     const file = @embedFile("wasi_hello_world.wasm");
     try testForOptions(file, .{});
 }

--- a/tests/test.zig
+++ b/tests/test.zig
@@ -31,11 +31,11 @@ fn testForOptions(content: []const u8, options: Options) !void {
         try testing.expectEqual(len, module.functions.data.len);
     }
 
-    for (options.export_names) |name, i| {
+    for (options.export_names, 0..) |name, i| {
         try testing.expectEqualStrings(name, module.exports.data[i].name);
     }
 
-    for (options.locals) |local, i| {
+    for (options.locals, 0..) |local, i| {
         for (module.code.data[i].locals) |code_local| {
             if (local.local == code_local.valtype) {
                 try testing.expectEqual(local.count, code_local.count);
@@ -70,7 +70,7 @@ test "tests/call_indirect.wasm" {
 test "tests/wasi_hello_world.wasm except code" {
     const file = @embedFile("wasi_hello_world.wasm");
     var stream = std.io.fixedBufferStream(file);
-    var options : wasmparser.parser.Options = .{};
+    var options: wasmparser.parser.Options = .{};
     // skip code section
     options.skip_section[@enumToInt(std.wasm.Section.code)] = true;
     var result = try wasmparser.parser.parseWithOptions(ally, stream.reader(), options);
@@ -80,6 +80,5 @@ test "tests/wasi_hello_world.wasm except code" {
 test "tests/wasi_hello_world.wasm" {
     // This is not working, seems something not supported by parser in code section
     const file = @embedFile("wasi_hello_world.wasm");
-    try testForOptions(file, .{
-    });
+    try testForOptions(file, .{});
 }


### PR DESCRIPTION
This was causing the `"tests/wasi_hello_world.wasm"` test to fail.
I also updated to the latest Zig master, including support for the new package manager.